### PR TITLE
Loading HTML from current bundle

### DIFF
--- a/Pod/Classes/SCLPlayerViewController.m
+++ b/Pod/Classes/SCLPlayerViewController.m
@@ -174,7 +174,7 @@ NSString* const SCLPlayerPropertyVisual        = @"visual";
     self.loadDidFail = NO;
     self.isLoadingPlayer = YES;
     
-    NSURL* scURL = [[NSBundle mainBundle] URLForResource:@"soundcloudPlayer" withExtension:@"html"];
+    NSURL* scURL = [[NSBundle bundleForClass:[self class]] URLForResource:@"soundcloudPlayer" withExtension:@"html"];
     NSAssert(scURL, @"Unable to find soundcloudPlayer.html in source bundle");
     
     NSString* urlParam = [[self.initialURL absoluteString] stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLHostAllowedCharacterSet]];


### PR DESCRIPTION
When used in a CocoaPod in Swift, the Pods-framework has a different
bundle and the resource could not be found. This fixes this